### PR TITLE
Update hkubectl download files via workflow when hkubectl updates

### DIFF
--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -19,11 +19,14 @@ jobs:
 
       - name: Download latest release files from hkubectl
         run: |
+          set -e
           export latestVersion=$(curl -s https://api.github.com/repos/kube-HPC/hkubectl/releases/latest | jq -r .tag_name)
-          mkdir -p site/hkubectl_files
-          curl -L https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-linux -o hkubectl_files/hkubectl-linux
-          curl -L https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-macos -o hkubectl_files/hkubectl-macos
-          curl -L https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-win.exe -o hkubectl_files/hkubectl-win.exe
+          mkdir -p site/hkubectl_files || { echo "Failed to create directory"; exit 1; }
+          df -h
+          ls -ld site site/hkubectl_files
+          curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-linux -o site/hkubectl_files/hkubectl-linux
+          curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-macos -o site/hkubectl_files/hkubectl-macos
+          curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-win.exe -o site/hkubectl_files/hkubectl-win.exe
 
       - name: Commit and push updated files to kube-HPC.github.io
         run: |

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -2,8 +2,9 @@ name: Update Download Files from hkubectl Release
 
 # Trigger the workflow when a new release is published in the hkubectl repository
 on:
-  repository_dispatch:
-    types: [hkubectl-release]
+  # Triggers the workflow on push or pull request events but only for the master branch.
+  pull_request:
+    branches: [ source ]
 
 jobs:
   update-files:

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: kube-HPC/kube-HPC.github.io
-          ref: source
+          ref: test_branch_1
 
       - name: Download latest release files from hkubectl
         run: |
@@ -31,8 +31,9 @@ jobs:
           set -e
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
+          git fetch origin
           git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
           git add -A
-          git commit -m "Update hkubectl download files to the latest release"
+          git commit -m "Update hkubectl download files to the latest release" --allow-empty
           git push origin test_branch_1
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -39,5 +39,5 @@ jobs:
           git checkout -b hkubectl_updates_via_workflow || git checkout hkubectl_updates_via_workflow
           git add -A
           git commit -m "Update hkubectl download files to the latest release" --allow-empty
-          git push --set-upstream origin hkubectl_updates_via_workflow
+          git push --set-upstream origin test_branch_1
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -21,23 +21,18 @@ jobs:
         run: |
           set -e
           export latestVersion=$(curl -s https://api.github.com/repos/kube-HPC/hkubectl/releases/latest | jq -r .tag_name)
-          echo "Latest version: $latestVersion"
-          mkdir -p site/hkubectl_files || { echo "Failed to create directory"; exit 1; }
+          mkdir -p site/hkubectl_files
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-linux -o site/hkubectl_files/hkubectl-linux
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-macos -o site/hkubectl_files/hkubectl-macos
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-win.exe -o site/hkubectl_files/hkubectl-win.exe
-          echo "Downloaded files:"
-          ls -R site
 
       - name: Commit and push updated files to kube-HPC.github.io
         run: |
           set -e
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          ls site/hkubectl_files || { echo "No files found"; exit 1; }
-          git fetch origin
           git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
           git add -A
-          git commit -m "Update hkubectl download files to the latest release" --allow-empty
+          git commit -m "Update hkubectl download files to the latest release"
           git push origin test_branch_1
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -35,7 +35,9 @@ jobs:
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           ls site/hkubectl_files || { echo "No files found"; exit 1; }
+          # Ensure we are on the correct branch
+          git checkout -b hkubectl_updates_via_workflow || git checkout hkubectl_updates_via_workflow
           git add -A
           git commit -m "Update hkubectl download files to the latest release" --allow-empty
-          git push origin hkubectl_updates_via_workflow
+          git push --set-upstream origin hkubectl_updates_via_workflow
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -35,9 +35,9 @@ jobs:
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           ls site/hkubectl_files || { echo "No files found"; exit 1; }
-          # Ensure we are on the correct branch
-          git checkout -b hkubectl_updates_via_workflow || git checkout hkubectl_updates_via_workflow
+          git fetch origin
+          git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
           git add -A
           git commit -m "Update hkubectl download files to the latest release" --allow-empty
-          git push --set-upstream origin test_branch_1
+          git push origin test_branch_1
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -33,6 +33,6 @@ jobs:
           git config --global user.name "GitHub Action"
           git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
           git add -A
-          git commit -m "Update hkubectl download files to the latest release" --allow-empty
+          git commit -m "Update hkubectl download files to the latest release"
           git push origin test_branch_1
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Commit and push updated files to kube-HPC.github.io
         run: |
           set -e
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
           ls site/hkubectl_files || { echo "No files found"; exit 1; }
-          git add site/hkubectl_files/* || { echo "git add failed"; exit 1; }
-          git commit -m "Update hkubectl download files to the latest release" || echo "No changes to commit"
-          git push origin main
+          git add -A
+          git commit -m "Update hkubectl download files to the latest release" --allow-empty
+          git push origin hkubectl_updates_via_workflow
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -2,7 +2,7 @@ name: Update Download Files from hkubectl Release
 
 # Trigger the workflow when a new release is published in the hkubectl repository
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch.
+  # Triggers the workflow on push or pull request events but only for the master branch
   pull_request:
     branches: [ source ]
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -1,0 +1,33 @@
+name: Update Download Files from hkubectl Release
+
+# Trigger the workflow when a new release is published in the hkubectl repository
+on:
+  repository_dispatch:
+    types: [hkubectl-release]
+
+jobs:
+  update-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout kube-HPC.github.io repository
+        uses: actions/checkout@v2
+        with:
+          repository: kube-HPC/kube-HPC.github.io
+          ref: main
+
+      - name: Download latest release files from hkubectl
+        run: |
+          export latestVersion=$(curl -s https://api.github.com/repos/kube-HPC/hkubectl/releases/latest | jq -r .tag_name)
+          mkdir -p site/hkubectl_files
+          curl -L https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-linux -o hkubectl_files/hkubectl-linux
+          curl -L https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-macos -o hkubectl_files/hkubectl-macos
+          curl -L https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-win.exe -o hkubectl_files/hkubectl-win.exe
+
+      - name: Commit and push updated files to kube-HPC.github.io
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add hkubectl_files/*
+          git commit -m "Update hkubectl download files to the latest release" || echo "No changes to commit"
+          git push origin main

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -19,11 +19,8 @@ jobs:
 
       - name: Download latest release files from hkubectl
         run: |
-          set -e
           export latestVersion=$(curl -s https://api.github.com/repos/kube-HPC/hkubectl/releases/latest | jq -r .tag_name)
           mkdir -p site/hkubectl_files || { echo "Failed to create directory"; exit 1; }
-          df -h
-          ls -ld site site/hkubectl_files
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-linux -o site/hkubectl_files/hkubectl-linux
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-macos -o site/hkubectl_files/hkubectl-macos
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-win.exe -o site/hkubectl_files/hkubectl-win.exe

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -31,7 +31,6 @@ jobs:
           set -e
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git fetch origin
           git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
           git add -A
           git commit -m "Update hkubectl download files to the latest release" --allow-empty

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: kube-HPC/kube-HPC.github.io
-          ref: main
+          ref: source
 
       - name: Download latest release files from hkubectl
         run: |

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -28,11 +28,14 @@ jobs:
 
       - name: Commit and push updated files to kube-HPC.github.io
         run: |
-          set -e
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
           git add -A
+                if ! git diff --cached --quiet; then
           git commit -m "Update hkubectl download files to the latest release"
           git push origin test_branch_1
+          else
+            echo "No changes to commit, skipping commit and push."
+          fi
 

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -19,16 +19,23 @@ jobs:
 
       - name: Download latest release files from hkubectl
         run: |
+          set -e
           export latestVersion=$(curl -s https://api.github.com/repos/kube-HPC/hkubectl/releases/latest | jq -r .tag_name)
+          echo "Latest version: $latestVersion"
           mkdir -p site/hkubectl_files || { echo "Failed to create directory"; exit 1; }
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-linux -o site/hkubectl_files/hkubectl-linux
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-macos -o site/hkubectl_files/hkubectl-macos
           curl -L --retry 3 --retry-delay 5 https://github.com/kube-HPC/hkubectl/releases/download/${latestVersion}/hkubectl-win.exe -o site/hkubectl_files/hkubectl-win.exe
+          echo "Downloaded files:"
+          ls -R site
 
       - name: Commit and push updated files to kube-HPC.github.io
         run: |
+          set -e
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          git add hkubectl_files/*
+          ls site/hkubectl_files || { echo "No files found"; exit 1; }
+          git add site/hkubectl_files/* || { echo "git add failed"; exit 1; }
           git commit -m "Update hkubectl download files to the latest release" || echo "No changes to commit"
           git push origin main
+

--- a/.github/workflows/update-hkubectl-downloads.yaml
+++ b/.github/workflows/update-hkubectl-downloads.yaml
@@ -2,9 +2,8 @@ name: Update Download Files from hkubectl Release
 
 # Trigger the workflow when a new release is published in the hkubectl repository
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  pull_request:
-    branches: [ source ]
+  repository_dispatch:
+    types: [hkubectl-release]
 
 jobs:
   update-files:
@@ -15,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: kube-HPC/kube-HPC.github.io
-          ref: test_branch_1
+          ref: source
 
       - name: Download latest release files from hkubectl
         run: |
@@ -30,11 +29,11 @@ jobs:
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git checkout test_branch_1 || git checkout -b test_branch_1 origin/test_branch_1
+          git checkout source || git checkout -b source origin/source
           git add -A
                 if ! git diff --cached --quiet; then
           git commit -m "Update hkubectl download files to the latest release"
-          git push origin test_branch_1
+          git push origin source
           else
             echo "No changes to commit, skipping commit and push."
           fi


### PR DESCRIPTION
A new workflow has been added, causing the download files to be updated once the hkubectl repository is updated.
Related Issue - https://github.com/kube-HPC/hkube/issues/2019

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/kube-HPC.github.io/59)
<!-- Reviewable:end -->
