### PR TITLE
added explanation about stateType (streaming algs priority)

### DIFF
--- a/site/learn/Streaming.md
+++ b/site/learn/Streaming.md
@@ -169,7 +169,11 @@ Streaming pipelines are built from Stateful and Stateless algorithms.
 ### Streaming Algorithm Priority
 Streaming algorithms have a special priority setting. To use it, you need to set the `stateType` in your algorithm spec to either **stateless** or **stateful**.
 
-Once set, **stateful** algorithms will be given the highest priority and will be requested right away. **Stateless** algorithms will follow. These algorithms are prioritized over **batch algorithms**, which are only requested at specific intervals to manage pod launches more gradually.
+When set:  
+- **Stateful algorithms** - A Kubernetes Job is created and launched immediately. These jobs are given the highest priority and start execution right away.  
+- **Stateless algorithms** - Each algorithm runs as a Kubernetes Job, but these jobs are launched after all stateful ones.  
+- **Algorithms without a `stateType` field** - These jobs are created after the stateless ones at controlled intervals to manage cluster load and avoid excessive pod launches at once.
+> Note - All jobs are re-requested as needed, following the interval defined in the config settings.
 
 Example for algorithm spec:
 ```json

--- a/site/learn/Streaming.md
+++ b/site/learn/Streaming.md
@@ -167,13 +167,11 @@ Streaming pipelines are built from Stateful and Stateless algorithms.
 ---
 
 ### Streaming Algorithm Priority
-Streaming algorithms have a special priority setting. To use it, you need to set the `stateType` in your algorithm spec to either **stateless** or **stateful**.
+If you are experiencing slower algorithm allocation in streaming pipelines, these algorithms have a special priority setting. To use it, you need to set the `stateType` in your algorithm spec to either **stateless** or **stateful**.
 
 When set:  
-- **Stateful algorithms** - A Kubernetes Job is created and launched immediately. These jobs are given the highest priority and start execution right away.  
-- **Stateless algorithms** - Each algorithm runs as a Kubernetes Job, but these jobs are launched after all stateful ones.  
-- **Algorithms without a `stateType` field** - These jobs are created after the stateless ones at controlled intervals to manage cluster load and avoid excessive pod launches at once.
-> Note - All jobs are re-requested as needed, following the interval defined in the config settings.
+- **Stateful** - A Kubernetes Job is created and launched immediately. These jobs are given the highest priority and start execution right away.  
+- **Stateless** - Jobs are launched after all stateful ones.  
 
 Example for algorithm spec:
 ```json

--- a/site/learn/Streaming.md
+++ b/site/learn/Streaming.md
@@ -38,7 +38,7 @@ In the wizard, you have 3 steps:
 
 
 ## Features
-HKube streaming pipeline supports:
+HKube streaming pipeline uses Stateful and Stateless algorithms, and supports:
 
 ### Unique data transportation
 HKube has its own data transportation system, enabling direct data transfer between nodes in a manner that ensures the following
@@ -163,6 +163,27 @@ Streaming pipelines are built from Stateful and Stateless algorithms.
 }
 ```
 ![StreamFlowExample2](../../img/streaming/StreamingFlowExample2.png)
+
+---
+
+### Streaming Algorithm Priority
+Streaming algorithms have a special priority setting. To use it, you need to set the `stateType` in your algorithm spec to either **stateless** or **stateful**.
+
+Once set, **stateful** algorithms will be given the highest priority and will be requested right away. **Stateless** algorithms will follow. These algorithms are prioritized over **batch algorithms**, which are only requested at specific intervals to manage pod launches more gradually.
+
+Example for algorithm spec:
+```json
+{
+    "name": "stateful-alg",
+    "cpu": 1,
+    "gpu": 0,
+    "mem": "256Mi",
+    "stateType": "stateful",
+    "algorithmImage": "hkube/algorithm-example-python"
+}
+```
+
+---
 
 ### Advanced
 


### PR DESCRIPTION
Added explanation for stateType field in algorithm spec under `Streaming Algorithm Priority` (At `Streaming` page).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/kube-HPC.github.io/72)
<!-- Reviewable:end -->
